### PR TITLE
Fix broken support link that explains logzioType

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This appender uses  [LogzioSender](https://github.com/logzio/logzio-java-sender)
 | Parameter          | Default                              | Explained  |
 | ------------------ | ------------------------------------ | ----- |
 | **logzioToken**              | *None*                                 | Your Logz.io token, which can be found under "settings" in your account, If the value begins with `$` then the appender looks for an environment variable with the name specified. For example: `$LOGZIO_TOKEN` will look for environment variable named `LOGZIO_TOKEN` |
-| **logzioType**               | *java*                                 | The [log type](http://support.logz.io/support/solutions/articles/6000103063-what-is-type-) for that appender |
+| **logzioType**               | *java*                                 | The [log type](https://support.logz.io/hc/en-us/articles/209486049-What-is-Type-) for that appender |
 | **drainTimeoutSec**       | *5*                                    | How often the appender should drain the buffer (in seconds) |
 | **fileSystemFullPercentThreshold** | *98*                                   | The percent of used file system space at which the appender will stop buffering. When we will reach that percentage, the file system in which the buffer is stored will drop all new logs until the percentage of used space drops below that threshold. Set to -1 to never stop processing new logs |
 | **bufferDir**          | *System.getProperty("java.io.tmpdir")* | Where the appender should store the buffer |


### PR DESCRIPTION
The link that explains what `logzioType` currently links to https://support.logz.io/support/solutions/articles/6000103063-what-is-type which doesn't seem to exist.

I managed to track down the link that explains the "Type", and updated the README accordingly to instead link here https://support.logz.io/hc/en-us/articles/209486049-What-is-Type-